### PR TITLE
Change filesystem permission to minimal

### DIFF
--- a/br.gov.rfb.irpf.yml
+++ b/br.gov.rfb.irpf.yml
@@ -32,7 +32,7 @@ finish-args:
   - --share=network
   # Needs to save files locally
   - --filesystem=xdg-documents
-  - --filesystem=home
+  - --filesystem=home/ProgramasRFB
   - --env=PATH=$PATH:/app/jre/bin:/usr/bin
 # cleanup:
 #   - '/IRPF2021'


### PR DESCRIPTION
The app, by default, only needs to access the folder ~/ProgramasRFB. If the user wants to give more permission, information can be given in README.md